### PR TITLE
Remove deprecated functions

### DIFF
--- a/install/extra/config.phpsample.php
+++ b/install/extra/config.phpsample.php
@@ -28,10 +28,6 @@ if (PHP_VERSION_ID < REQUIRED_PHP)
 die('PHP '.REQUIRED_PHP_VERSION.' or higher is required.');
 if (PHP_INT_SIZE < 8)
 die('A 64bit or higher OS + Processor is required.');
-if (get_magic_quotes_gpc() || get_magic_quotes_runtime() || ini_get('magic_quotes_sybase'))
-die('PHP is configured incorrectly. Turn off magic quotes.');
-if (ini_get('register_long_arrays') || ini_get('register_globals') || ini_get('safe_mode'))
-die('PHP is configured incorrectly. Turn off safe_mode, register_globals and register_long_arrays.');
 define('EMAIL_CONFIRM', true);
 define('SQL_DEBUG', 1);
 define('XBT_TRACKER', false);


### PR DESCRIPTION
get_magic_quotes_gpc 

Warning
This function has been DEPRECATED as of PHP 7.4.0. Relying on this function is highly discouraged.
